### PR TITLE
added dependency to update fileType if currentDocument changes

### DIFF
--- a/src/state/actions.ts
+++ b/src/state/actions.ts
@@ -26,6 +26,14 @@ export const setDocumentLoading = (value: boolean): SetDocumentLoading => ({
   value,
 });
 
+export const UPDATE_DOCUMENT_NUMBER: string = "UPDATE_DOCUMENT_NUMBER";
+export interface DocumentNumber {
+  type: typeof UPDATE_DOCUMENT_NUMBER;
+}
+export const updateDocumentNumber = (): DocumentNumber => ({
+  type: UPDATE_DOCUMENT_NUMBER,
+});
+
 export const NEXT_DOCUMENT: string = "NEXT_DOCUMENT";
 export interface NextDocument {
   type: typeof NEXT_DOCUMENT;

--- a/src/state/reducer.ts
+++ b/src/state/reducer.ts
@@ -1,6 +1,7 @@
 import { DocRenderer, IConfig, IDocument } from "../types";
 import {
   MainStateActions,
+  UPDATE_DOCUMENT_NUMBER,
   NEXT_DOCUMENT,
   PREVIOUS_DOCUMENT,
   SetAllDocuments,
@@ -61,6 +62,13 @@ export const mainStateReducer: MainStateReducer = (
     case SET_DOCUMENT_LOADING: {
       const { value } = action as SetDocumentLoading;
       return { ...state, documentLoading: value };
+    }
+
+    case UPDATE_DOCUMENT_NUMBER: {
+      return {
+        ...state,
+        currentFileNo: state.documents.indexOf( state.currentDocument as IDocument )
+      }
     }
 
     case NEXT_DOCUMENT: {

--- a/src/utils/useDocumentLoader.ts
+++ b/src/utils/useDocumentLoader.ts
@@ -3,9 +3,9 @@ import { DocViewerContext } from "../state";
 import {
   MainStateActions,
   setDocumentLoading,
-  updateCurrentDocument,
+  updateCurrentDocument, updateDocumentNumber,
 } from "../state/actions";
-import { IMainState } from "../state/reducer";
+import {IMainState, initialState} from "../state/reducer";
 import { DocRenderer } from "../types";
 import {
   defaultFileLoader,
@@ -46,6 +46,7 @@ export const useDocumentLoader = (): {
         const contentTypes = contentTypeRaw?.split(";") || [];
         const contentType = contentTypes.length ? contentTypes[0] : undefined;
 
+        dispatch(updateDocumentNumber())
         dispatch(
           updateCurrentDocument({
             ...currentDocument,
@@ -59,7 +60,7 @@ export const useDocumentLoader = (): {
       };
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [currentFileNo, documentURI]
+    [currentFileNo, documentURI, currentDocument]
   );
 
   useEffect(() => {


### PR DESCRIPTION
There was a bug with re-rendering and a document not displaying due to the fileType being undefined. This change adds the currentDocuments as a dependency to a hook that will update the fileType should the currentDocument be updated.

This can be visually seen by adding a conditional variable to a a component that will cause a re-render. For example, a button that changes the background color. Previously, when that color was changed and the component was re-rendered, the document would not show up due to the fileType being undefined. This change will reset that fileType and display the document should the component be re-rendered.