### PR TITLE
Ignore "AbortError" Exceptions thrown in `useDocumentLoader`

### DIFF
--- a/src/hooks/useDocumentLoader.ts
+++ b/src/hooks/useDocumentLoader.ts
@@ -53,7 +53,11 @@ export const useDocumentLoader = (): {
             fileType: contentType || undefined,
           })
         );
-      });
+      }).catch(error => {
+        if (error?.name !== 'AbortError') {
+          throw error;
+        }
+      })
 
       return () => {
         controller.abort();

--- a/src/hooks/useDocumentLoader.ts
+++ b/src/hooks/useDocumentLoader.ts
@@ -53,11 +53,11 @@ export const useDocumentLoader = (): {
             fileType: contentType || undefined,
           })
         );
-      }).catch(error => {
+      }).catch((error) => {
         if (error?.name !== 'AbortError') {
           throw error;
         }
-      })
+      });
 
       return () => {
         controller.abort();


### PR DESCRIPTION
## Issue 🐛

Some browsers, namely Chrome/Chromium, toss DOMExceptions with name "AbortError" to the error console. This causes issues when this package is being used in certain testing environments, like Cypress, and generally clogs up the console.

<img width="517" alt="Screenshot 2023-01-20 at 9 10 32 AM" src="https://user-images.githubusercontent.com/2932025/213721607-49a11092-5e15-4ac7-a64a-130ac06ae27c.png">

## Reproduction 🔁

To reproduce this issue:

1. Load storybook > DocViewer > Default in Chrome.
2. Go to the Network inspector and disable the cache and set throttling to 2G (makes it easier to click fast enough to cause the abort).
3. Click through the document selection arrows rapidly.

## Cause 🔬

When cleaning up the first effect in `useDocumentLoader` the abort signal is sent, if the request has not finished this abortion goes unhandled and therefore reaches the console.

This actual exception is totally benign, since the fetch gets recalled when the effect is next running, so it is safe to ignore it.

## Fix 🚧

Added a catch block within the `useDocumentLoader` effect that previously didn't have one. If the error name is not `AbortError`, it will rethrow the error, else it will fail silently.

## Demo 🎬

### Behavior Before

https://user-images.githubusercontent.com/2932025/213722390-81ed763b-edfe-4bdd-9c34-2550442bfc40.mov

### Behavior After

https://user-images.githubusercontent.com/2932025/213722444-9e5cb942-a76d-4209-92cd-d2df3f0ab6a4.mov
