### PR TITLE
fix pdfPluginPageNumber string for german translation

### DIFF
--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -6,5 +6,5 @@
   "msgPluginRecipients": "Empfänger",
   "msgPluginSender": "Absender",
   "pdfPluginLoading": "Wird geladen...",
-  "pdfPluginPageNumber": "Seite {{ aktuelleSeite }}/{{ allPagesCount }}"
+  "pdfPluginPageNumber": "Seite {{ currentPage }}/{{ allPagesCount }}"
 }


### PR DESCRIPTION
The parameter "currentPage" was also translated to german ("aktuelleSeite"). 

This is fixed with this pull request