### PR TITLE
Use non legacy version of pdfjs package

### DIFF
--- a/src/renderers/pdf/index.tsx
+++ b/src/renderers/pdf/index.tsx
@@ -7,7 +7,7 @@ import PDFPages from "./components/pages/PDFPages";
 import PDFControls from "./components/PDFControls";
 import { PDFProvider } from "./state";
 
-pdfjs.GlobalWorkerOptions.workerSrc = `https://unpkg.com/pdfjs-dist@${pdfjs.version}/legacy/build/pdf.worker.min.js`;
+pdfjs.GlobalWorkerOptions.workerSrc = `https://unpkg.com/pdfjs-dist@2.12.313/build/pdf.worker.min.js`;
 
 const PDFRenderer: DocRenderer = ({ mainState }) => {
   return (


### PR DESCRIPTION
The dependency on a legacy version of pdfjs causes an unsafe eval warning on build. Switching to non legacy build silences the warning.