### PR TITLE
Export renderers individually

### DIFF
--- a/src/renderers/index.ts
+++ b/src/renderers/index.ts
@@ -23,3 +23,17 @@ export const DocViewerRenderers = [
   GIFRenderer,
   VideoRenderer,
 ];
+
+export {
+  BMPRenderer,
+  HTMLRenderer,
+  JPGRenderer,
+  MSDocRenderer,
+  PDFRenderer,
+  PNGRenderer,
+  TIFFRenderer,
+  TXTRenderer,
+  CSVRenderer,
+  GIFRenderer,
+  VideoRenderer,
+};


### PR DESCRIPTION
Renderers should be exported individually to allow this suggested in the docs: `import DocViewer, { PDFRenderer, PNGRenderer } from "@cyntler/react-doc-viewer";`

https://github.com/cyntler/react-doc-viewer/issues/173