### PR TITLE
Fix: Missing text and annotationlayer imports for React-PDF

### DIFF
--- a/src/renderers/pdf/index.tsx
+++ b/src/renderers/pdf/index.tsx
@@ -5,6 +5,8 @@ import { DocRenderer, IStyledProps } from "../..";
 import PDFPages from "./components/pages/PDFPages";
 import PDFControls from "./components/PDFControls";
 import { PDFProvider } from "./state";
+import "react-pdf/dist/Page/AnnotationLayer.css";
+import "react-pdf/dist/Page/TextLayer.css";
 
 pdfjs.GlobalWorkerOptions.workerSrc = `//unpkg.com/pdfjs-dist@${pdfjs.version}/build/pdf.worker.min.js`;
 

--- a/src/renderers/pdf/index.tsx
+++ b/src/renderers/pdf/index.tsx
@@ -5,8 +5,8 @@ import { DocRenderer, IStyledProps } from "../..";
 import PDFPages from "./components/pages/PDFPages";
 import PDFControls from "./components/PDFControls";
 import { PDFProvider } from "./state";
-import "react-pdf/dist/Page/AnnotationLayer.css";
-import "react-pdf/dist/Page/TextLayer.css";
+import "react-pdf/dist/esm/Page/AnnotationLayer.css";
+import "react-pdf/dist/esm/Page/TextLayer.css";
 
 pdfjs.GlobalWorkerOptions.workerSrc = `//unpkg.com/pdfjs-dist@${pdfjs.version}/build/pdf.worker.min.js`;
 


### PR DESCRIPTION
@cyntler 
The PDFRender uses PDF-React as Library. There the imports for the Text and Annotationlayer are missing. This causes 
incorrect render behaviour. I added the missing imports according to the PDF-React documentation: [Support for text and annotationlayer ](https://github.com/wojtekmaj/react-pdf/blob/main/packages/react-pdf/README.md#support-for-annotations). This issue was likely cause by updating the React-PDF dependency in #88  from 5.7.2 (no text and annotationlayer support) to 7.5.0.

### Before:
The text and annotationlayer were improperly rendered below the pdf canvas. This also prevented from text being directly highlightable and therefore copyable from the rendered PDF.
<img width="448" alt="grafik" src="https://github.com/cyntler/react-doc-viewer/assets/38780545/a51de182-5005-4e99-8944-04c29913bb73">

### After:
The text and annotationlayer are correctly rendered on top of the pdf canvas. The text is highlightable and copyable.
<img width="721" alt="grafik" src="https://github.com/cyntler/react-doc-viewer/assets/38780545/4babac6a-e989-44e0-b227-84a62ec21c89">
