### PR TITLE
feat: add callback function in config to get pdf currentpage and totalpage count

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,11 @@ You can provide a config object, which configures parts of the component as requ
       zoomJump: 0.2, // 0.1 as default,
     },
     pdfVerticalScrollByDefault: true, // false as default
+
+    // only applicable for pdf
+    getPdfData: ({ currentPage, totalPages }) => {
+      console.log("pdf data", totalPages, currentPage);
+    },
   }}
 />
 ```

--- a/src/models.ts
+++ b/src/models.ts
@@ -2,6 +2,11 @@ import { FC, ReactElement, ComponentType, PropsWithChildren } from "react";
 import { IMainState } from "./store/mainStateReducer";
 import { FileLoaderFunction } from "./utils/fileLoaders";
 
+export interface IpdfDataProps {
+  currentPage: number;
+  totalPages: number;
+}
+
 export interface IConfig {
   header?: IHeaderConfig;
   loadingRenderer?: ILoadingRendererConfig;
@@ -9,6 +14,7 @@ export interface IConfig {
   csvDelimiter?: string;
   pdfZoom?: IPdfZoomConfig;
   pdfVerticalScrollByDefault?: boolean;
+  getPdfData?: (props: IpdfDataProps) => void | null | undefined;
 }
 
 export interface ILoadingRendererConfig {


### PR DESCRIPTION
Added config option to get pdf data

// only applicable for pdf
getPdfData: ({ currentPage, totalPages }) => {
  console.log("pdf data", totalPages, currentPage);
},

this config callback function is called when user changes the pdf page in  horizontal  scroll or scrolls down to change page in vertical scroll

Also updated readme file