### PR TITLE
Removed type from AvailableLanguages export

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,5 +4,5 @@ export default DocViewer;
 export { DocViewerRenderers } from "./renderers";
 export * from "./models";
 export * from "./utils/fileLoaders";
-export { type AvailableLanguages } from "./i18n";
+export { AvailableLanguages } from "./i18n";
 export * from "./renderers";


### PR DESCRIPTION
Removal of the `type` from the export would resolve the following issue https://github.com/cyntler/react-doc-viewer/issues/153

Also prevents needing to make local changes in node_modules, regardless of whether they're excluded from tsc as this error still occurs.