### PR TITLE
fix: syntax error react-pdf in nextjs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@types/papaparse": "^5.3.9",
         "mustache": "^4.2.0",
         "papaparse": "^5.4.1",
-        "react-pdf": "7.5.0",
+        "react-pdf": "7.7.1",
         "styled-components": "^6.0.8"
       },
       "devDependencies": {
@@ -61,7 +61,8 @@
       },
       "peerDependencies": {
         "react": ">=16.13.1",
-        "react-dom": ">=16.13.1"
+        "react-dom": ">=16.13.1",
+        "react-pdf": ">=7"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -8166,7 +8167,7 @@
       "version": "15.7.9",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.9.tgz",
       "integrity": "sha512-n1yyPsugYNSmHgxDFjicaI2+gCNjsBck8UX9kuofAKlc0h1bL+20oSF72KeNaW2DUlesbEVCFgyV2dPGTiY42g==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/@types/q": {
       "version": "1.5.7",
@@ -8190,7 +8191,7 @@
       "version": "18.2.34",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.34.tgz",
       "integrity": "sha512-U6eW/alrRk37FU/MS2RYMjx0Va2JGIVXELTODaTIYgvWGCV4Y4TfTUzG8DdmpDNIT0Xpj/R7GfyHOJJrDttcvg==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -8256,7 +8257,7 @@
       "version": "0.16.5",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.5.tgz",
       "integrity": "sha512-s/FPdYRmZR8SjLWGMCuax7r3qCWQw9QKHzXVukAuuIJkXkDRwp+Pu5LMIVFi0Fxbav35WURicYr8u1QsoybnQw==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/@types/semver": {
       "version": "7.5.4",
@@ -12757,7 +12758,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -25240,6 +25240,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
       "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -25581,6 +25582,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
       "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
@@ -25631,18 +25633,19 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/react-pdf": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/react-pdf/-/react-pdf-7.5.0.tgz",
-      "integrity": "sha512-hX7SfQGd9T6pdd3H5HcR1VzrRCehkhnBh/tsyz9GO9cXrYHgoxupboVL2VCQpBBSak+/UQSMCj+3JTOdheuwwQ==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/react-pdf/-/react-pdf-7.7.1.tgz",
+      "integrity": "sha512-cbbf/PuRtGcPPw+HLhMI1f6NSka8OJgg+j/yPWTe95Owf0fK6gmVY7OXpTxMeh92O3T3K3EzfE0ML0eXPGwR5g==",
       "dependencies": {
         "clsx": "^2.0.0",
+        "dequal": "^2.0.3",
         "make-cancellable-promise": "^1.3.1",
         "make-event-props": "^1.6.0",
         "merge-refs": "^1.2.1",
         "pdfjs-dist": "3.11.174",
         "prop-types": "^15.6.2",
         "tiny-invariant": "^1.0.0",
-        "tiny-warning": "^1.0.0"
+        "warning": "^4.0.0"
       },
       "funding": {
         "url": "https://github.com/wojtekmaj/react-pdf?sponsor=1"
@@ -28550,6 +28553,7 @@
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
       "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
+      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
@@ -30573,11 +30577,6 @@
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.1.tgz",
       "integrity": "sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw=="
     },
-    "node_modules/tiny-warning": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
-    },
     "node_modules/titleize": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/titleize/-/titleize-3.0.0.tgz",
@@ -31532,6 +31531,14 @@
       "dev": true,
       "dependencies": {
         "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/watchpack": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@types/papaparse": "^5.3.9",
     "mustache": "^4.2.0",
     "papaparse": "^5.4.1",
-    "react-pdf": "7.5.0",
+    "react-pdf": "7.7.1",
     "styled-components": "^6.0.8"
   },
   "devDependencies": {
@@ -83,7 +83,11 @@
   },
   "peerDependencies": {
     "react": ">=16.13.1",
-    "react-dom": ">=16.13.1"
+    "react-dom": ">=16.13.1",
+    "react-pdf": ">=7"
+  },
+  "resolutions": {
+    "typescript": "^5.2.2"
   },
   "browserslist": {
     "production": [

--- a/src/renderers/pdf/index.tsx
+++ b/src/renderers/pdf/index.tsx
@@ -5,8 +5,6 @@ import { DocRenderer, IStyledProps } from "../..";
 import PDFPages from "./components/pages/PDFPages";
 import PDFControls from "./components/PDFControls";
 import { PDFProvider } from "./state";
-import "react-pdf/dist/esm/Page/AnnotationLayer.css";
-import "react-pdf/dist/esm/Page/TextLayer.css";
 
 pdfjs.GlobalWorkerOptions.workerSrc = `//unpkg.com/pdfjs-dist@${pdfjs.version}/build/pdf.worker.min.js`;
 


### PR DESCRIPTION

Hey, @DawnSheedy many users are facing a [syntax error in the react-pdf issue](https://github.com/cyntler/react-doc-viewer/pull/185). As far as I know, it's due to changes made in [this PR](https://github.com/cyntler/react-doc-viewer/pull/185).

Regarding the previous issue, I think we can just update the react-pdf version. I'm sure it's fixed now. If we need these CSS, we can manually import them in our project instead of using the built-in react-doc-viewer.

Also, I added the react-pdf library as a peerDependency. This change will prevent the installation of react-pdf library at an inside level.