### PR TITLE
fix: Fixing issue with unknown chars breaking pages

### DIFF
--- a/src/renderers/pdf/components/pages/PDFPages.tsx
+++ b/src/renderers/pdf/components/pages/PDFPages.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable */
 import React, { FC, useContext, useEffect } from "react";
-import { Document } from "react-pdf";
+import { Document, pdfjs } from "react-pdf";
 import styled from "styled-components";
 import { useTranslation } from "../../../../hooks/useTranslation";
 import { PDFContext } from "../../state";
@@ -29,6 +29,10 @@ const PDFPages: FC<{}> = () => {
       file={currentDocument.fileData}
       onLoadSuccess={({ numPages }) => dispatch(setNumPages(numPages))}
       loading={<span>{t("pdfPluginLoading")}</span>}
+      options={{
+        cMapUrl: `https://cdn.jsdelivr.net/npm/pdfjs-dist@${pdfjs.version}/cmaps/`,
+        cMapPacked: true,
+      }}
     >
       {paginated ? <PDFSinglePage /> : <PDFAllPages />}
     </DocumentPDF>


### PR DESCRIPTION
We're having an issue with a few PDFs causing "Aw Snap, something went wrong..." on Google Chrome. It's been related to not having CMAPS properly configured for react-pdf.

This PR fixes it (and brings it on demand from CDN, the same way the worker works)