### PR TITLE
fix: :bug: enable handling annotation and text layers for pdfs

### DIFF
--- a/src/renderers/pdf/index.tsx
+++ b/src/renderers/pdf/index.tsx
@@ -5,6 +5,8 @@ import { DocRenderer, IStyledProps } from "../..";
 import PDFPages from "./components/pages/PDFPages";
 import PDFControls from "./components/PDFControls";
 import { PDFProvider } from "./state";
+import 'react-pdf/dist/Page/AnnotationLayer.css';
+import 'react-pdf/dist/Page/TextLayer.css';
 
 pdfjs.GlobalWorkerOptions.workerSrc = `//unpkg.com/pdfjs-dist@${pdfjs.version}/build/pdf.worker.min.js`;
 


### PR DESCRIPTION
Pdf reader were causing warnings when required styles werent provided