### PR TITLE
Ensure PDFControls do not scroll off the screen when zooming

### DIFF
--- a/src/components/ProxyRenderer.tsx
+++ b/src/components/ProxyRenderer.tsx
@@ -117,11 +117,7 @@ export const ProxyRenderer: FC = () => {
   );
 
   return (
-    <Container
-      id="proxy-renderer"
-      data-testid="proxy-renderer"
-      ref={containerRef}
-    >
+    <div id="proxy-renderer" data-testid="proxy-renderer" ref={containerRef}>
       <Contents
         {...{
           state,
@@ -134,14 +130,9 @@ export const ProxyRenderer: FC = () => {
           t,
         }}
       />
-    </Container>
+    </div>
   );
 };
-
-const Container = styled.div`
-  display: flex;
-  flex: 1;
-`;
 
 const LoadingContainer = styled.div`
   display: flex;


### PR DESCRIPTION
This change aims to ensure that the PDF zoom controls do not scroll off the screen as consumers zoom in.  The PDFControls will now stay positioned with the existing HeaderBar.

Before:
![image](https://github.com/cyntler/react-doc-viewer/assets/123757541/a6985ad3-294b-4a4f-ae86-6c07d7df4b60)

After:
![image](https://github.com/cyntler/react-doc-viewer/assets/123757541/1a5457a7-0842-4079-85e3-1ac53af04c78)
