### PR TITLE
Export locales so consumers can set language without duplicating code

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -28,6 +28,8 @@ export const locales = {
   se,
 };
 
+export const supportedLanguages = Object.keys(locales);
+
 export type AvailableLanguages = keyof typeof locales;
 
 export const defaultLanguage: AvailableLanguages = "en";

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,5 +7,5 @@ export default DocViewer;
 export { DocViewerRenderers } from "./renderers";
 export * from "./models";
 export * from "./utils/fileLoaders";
-export { type AvailableLanguages, locales } from "./i18n";
+export { type AvailableLanguages, supportedLanguages } from "./i18n";
 export * from "./renderers";

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,5 +7,5 @@ export default DocViewer;
 export { DocViewerRenderers } from "./renderers";
 export * from "./models";
 export * from "./utils/fileLoaders";
-export { type AvailableLanguages } from "./i18n";
+export { type AvailableLanguages, locales } from "./i18n";
 export * from "./renderers";


### PR DESCRIPTION
Consumers that want to set DocViewer language to a valid value from `AvailableLanguages` are currently forced to recreate an array of locales to compare against since `AvailableLanguages` is a union type and its values are compiled away and not available at run time.

This change aims to export the locales so that consumers can avoid duplicating the locales within their code. The goal would be to use  navigator.language.split('-')[0] to produce a valid `AvailableLanguages`.