### PR TITLE
Proper dataurl charset handling

### DIFF
--- a/src/renderers/html/index.tsx
+++ b/src/renderers/html/index.tsx
@@ -6,7 +6,8 @@ import { dataURLFileLoader } from "../../utils/fileLoaders";
 const HTMLRenderer: DocRenderer = ({ mainState: { currentDocument } }) => {
   useEffect(() => {
     const b64String = currentDocument?.fileData as string;
-    const bodyBase64 = b64String?.replace("data:text/html;base64,", "") || "";
+    const bodyBase64 =
+      b64String?.replace(/^data:text\/html;([^;]*?;)?base64,/, "") || "";
     const body: string = window.atob(bodyBase64);
 
     const iframeCont = document.getElementById(

--- a/src/renderers/html/index.tsx
+++ b/src/renderers/html/index.tsx
@@ -6,9 +6,24 @@ import { dataURLFileLoader } from "../../utils/fileLoaders";
 const HTMLRenderer: DocRenderer = ({ mainState: { currentDocument } }) => {
   useEffect(() => {
     const b64String = currentDocument?.fileData as string;
+
+    let encoding = "";
     const bodyBase64 =
-      b64String?.replace(/^data:text\/html;([^;]*?;)?base64,/, "") || "";
-    const body: string = window.atob(bodyBase64);
+      b64String?.replace(
+        /^data:text\/html;(?:charset=([^;]*);)?base64,/,
+        (_, charset) => {
+          encoding = charset;
+          return "";
+        },
+      ) || "";
+    let body: string = window.atob(bodyBase64);
+
+    if (encoding) {
+      // decode charset
+      const buffer = new Uint8Array(body.length);
+      for (let i = 0; i < body.length; i++) buffer[i] = body.charCodeAt(i);
+      body = new TextDecoder(encoding).decode(buffer);
+    }
 
     const iframeCont = document.getElementById(
       "html-body",


### PR DESCRIPTION
- fix for handling data urls with charsets, e.g., data:text/html;charset=utf-8;base64,...
- properly decode unicode charsets

Currently, when viewing data urls with charsets, the app crashes because the header isn't stripped and base64 decoding (window.atob) throws an error due to invalid base64 chars. This uses a regex for stripping the header with any charset, but also extracts the charset and uses TextDecoder to convert the binary string into a unicode string before being written to the iframe (if necessary).