### PR TITLE
feat: Make PDFRender Support non-latin characters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,7 @@
         "vite": "^5.2.12",
         "vite-plugin-dts": "^3.9.1",
         "vite-plugin-node-polyfills": "^0.22.0",
+        "vite-plugin-static-copy": "^1.0.6",
         "vitest": "^1.6.0",
         "vitest-fetch-mock": "^0.2.2",
         "webpack": "^5.91.0"
@@ -23770,6 +23771,24 @@
       },
       "peerDependencies": {
         "vite": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0"
+      }
+    },
+    "node_modules/vite-plugin-static-copy": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/vite-plugin-static-copy/-/vite-plugin-static-copy-1.0.6.tgz",
+      "integrity": "sha512-3uSvsMwDVFZRitqoWHj0t4137Kz7UynnJeq1EZlRW7e25h2068fyIZX4ORCCOAkfp1FklGxJNVJBkBOD+PZIew==",
+      "dev": true,
+      "dependencies": {
+        "chokidar": "^3.5.3",
+        "fast-glob": "^3.2.11",
+        "fs-extra": "^11.1.0",
+        "picocolors": "^1.0.0"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.0.0"
       }
     },
     "node_modules/vitest": {

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "vite": "^5.2.12",
     "vite-plugin-dts": "^3.9.1",
     "vite-plugin-node-polyfills": "^0.22.0",
+    "vite-plugin-static-copy": "^1.0.6",
     "vitest": "^1.6.0",
     "vitest-fetch-mock": "^0.2.2",
     "webpack": "^5.91.0"

--- a/src/renderers/pdf/components/pages/PDFPages.tsx
+++ b/src/renderers/pdf/components/pages/PDFPages.tsx
@@ -8,6 +8,13 @@ import { setNumPages } from "../../state/actions";
 import { initialPDFState } from "../../state/reducer";
 import { PDFAllPages } from "./PDFAllPages";
 import PDFSinglePage from "./PDFSinglePage";
+import { pdfjs } from "react-pdf";
+import "react-pdf/dist/Page/TextLayer.css";
+import "react-pdf/dist/Page/AnnotationLayer.css";
+
+const options = {
+  cMapUrl: `https://unpkg.com/pdfjs-dist@${pdfjs.version}/cmaps/`,
+};
 
 const PDFPages: FC<{}> = () => {
   const {
@@ -26,6 +33,7 @@ const PDFPages: FC<{}> = () => {
 
   return (
     <DocumentPDF
+      options={options}
       file={currentDocument.fileData}
       onLoadSuccess={({ numPages }) => dispatch(setNumPages(numPages))}
       loading={<span>{t("pdfPluginLoading")}</span>}

--- a/src/renderers/pdf/components/pages/PDFSinglePage.tsx
+++ b/src/renderers/pdf/components/pages/PDFSinglePage.tsx
@@ -4,11 +4,6 @@ import styled from "styled-components";
 import { IStyledProps } from "../../../..";
 import { useTranslation } from "../../../../hooks/useTranslation";
 import { PDFContext } from "../../state";
-import { pdfjs } from "react-pdf";
-
-const options = {
-  cMapUrl: `https://unpkg.com/pdfjs-dist@${pdfjs.version}/cmaps/`,
-};
 
 interface Props {
   pageNum?: number;

--- a/src/renderers/pdf/components/pages/PDFSinglePage.tsx
+++ b/src/renderers/pdf/components/pages/PDFSinglePage.tsx
@@ -1,9 +1,14 @@
 import React, { FC, useContext } from "react";
-import { Page } from "react-pdf";
+import { Document, Page } from "react-pdf";
 import styled from "styled-components";
 import { IStyledProps } from "../../../..";
 import { useTranslation } from "../../../../hooks/useTranslation";
 import { PDFContext } from "../../state";
+import { pdfjs } from "react-pdf";
+
+const options = {
+  cMapUrl: `https://unpkg.com/pdfjs-dist@${pdfjs.version}/cmaps/`,
+};
 
 interface Props {
   pageNum?: number;

--- a/src/renderers/pdf/components/pages/PDFSinglePage.tsx
+++ b/src/renderers/pdf/components/pages/PDFSinglePage.tsx
@@ -1,5 +1,5 @@
 import React, { FC, useContext } from "react";
-import { Document, Page } from "react-pdf";
+import { Page } from "react-pdf";
 import styled from "styled-components";
 import { IStyledProps } from "../../../..";
 import { useTranslation } from "../../../../hooks/useTranslation";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "skipLibCheck": true,
     "noEmit": true,
     "resolveJsonModule": true,
+    "module": "Preserve",
     "types": ["vitest/globals"]
   },
   "exclude": ["node_modules", "use-cases"]

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,16 @@
-import { defineConfig } from "vitest/config";
+import path from 'node:path';
+import { createRequire } from 'node:module';
+
+import { defineConfig, normalizePath } from 'vite';
 import dsv from "@rollup/plugin-dsv";
 import dts from "vite-plugin-dts";
 import { nodePolyfills } from "vite-plugin-node-polyfills";
+import { viteStaticCopy } from 'vite-plugin-static-copy';
+
+const require = createRequire(import.meta.url);
+
+const pdfjsDistPath = path.dirname(require.resolve('pdfjs-dist/package.json'));
+const cMapsDir = normalizePath(path.join(pdfjsDistPath, 'cmaps'));
 
 export default defineConfig({
   plugins: [
@@ -10,6 +19,14 @@ export default defineConfig({
     }),
     dsv(),
     nodePolyfills(),
+    viteStaticCopy({
+      targets: [
+        {
+          src: cMapsDir,
+          dest: '',
+        },
+      ],
+    }),
   ],
   build: {
     lib: {


### PR DESCRIPTION
Description: This pull request adds some updates according [https://github.com/wojtekmaj/react-pdf#support-for-annotations](url), which make PDFRender support for annotations, text layer and non-latin characters

before:
![before](https://github.com/cyntler/react-doc-viewer/assets/48916271/c1bf75aa-1245-460e-938a-22c843582790)

after:
![after](https://github.com/cyntler/react-doc-viewer/assets/48916271/c8c0807d-c2e6-4dba-873b-0b177d9d43b2)

Please review the changes and let me know if you have any feedback or questions. I'm happy to make any necessary updates.

Thank you for your time and consideration.