### PR TITLE
feat: add onFetchError prop

### DIFF
--- a/src/DocViewer.tsx
+++ b/src/DocViewer.tsx
@@ -28,6 +28,7 @@ export interface DocViewerProps {
   language?: AvailableLanguages;
   activeDocument?: IDocument;
   onDocumentChange?: (document: IDocument) => void;
+  onFetchError?: (error: Error) => void;
 }
 
 const DocViewer = forwardRef<DocViewerRef, DocViewerProps>((props, ref) => {

--- a/src/hooks/useDocumentLoader.ts
+++ b/src/hooks/useDocumentLoader.ts
@@ -23,7 +23,7 @@ export const useDocumentLoader = (): {
   CurrentRenderer: DocRenderer | null | undefined;
 } => {
   const { state, dispatch } = useContext(DocViewerContext);
-  const { currentFileNo, currentDocument, prefetchMethod } = state;
+  const { currentFileNo, currentDocument, prefetchMethod, onFetchError } = state;
 
   const { CurrentRenderer } = useRendererSelector();
 
@@ -56,7 +56,11 @@ export const useDocumentLoader = (): {
         })
         .catch((error) => {
           if (error?.name !== "AbortError") {
-            throw error;
+            if (onFetchError) {
+              onFetchError(error);
+            } else {
+              throw error;
+            }
           }
         });
 

--- a/src/store/DocViewerProvider.tsx
+++ b/src/store/DocViewerProvider.tsx
@@ -45,6 +45,7 @@ const DocViewerProvider = forwardRef<
     language,
     activeDocument,
     onDocumentChange,
+    onFetchError,
   } = props;
 
   const [state, dispatch] = useReducer<MainStateReducer>(mainStateReducer, {
@@ -66,6 +67,7 @@ const DocViewerProvider = forwardRef<
     language: language && locales[language] ? language : defaultLanguage,
     activeDocument,
     onDocumentChange,
+    onFetchError,
   });
 
   useEffect(() => {

--- a/src/store/mainStateReducer.ts
+++ b/src/store/mainStateReducer.ts
@@ -29,6 +29,7 @@ export type IMainState = {
   language: AvailableLanguages;
   activeDocument?: IDocument;
   onDocumentChange?: (document: IDocument) => void;
+  onFetchError?: (error: Error) => void;
 };
 
 export const initialState: IMainState = {


### PR DESCRIPTION
Fixes https://github.com/cyntler/react-doc-viewer/issues/266.

Usage:
```tsx
function App() {
  const handleOnFetchError = (error) => {
    console.error("Fetch error:", error);
    // Add any custom error handling here
  };

  return (
    <div className="App">
      <DocViewer
        documents={{ uri: "https://example.com/sample.pdf" }}
        onFetchError={handleOnFetchError}
      />
    </div>
  );
}
```