### PR TITLE
Load pdf.worker.mjs from dist folder

### DIFF
--- a/src/renderers/pdf/index.tsx
+++ b/src/renderers/pdf/index.tsx
@@ -7,7 +7,8 @@ import { PDFProvider } from "./state";
 import { pdfjs } from "react-pdf";
 
 pdfjs.GlobalWorkerOptions.workerSrc = new URL(
-  `https://unpkg.com/pdfjs-dist@${pdfjs.version}/build/pdf.worker.min.mjs`,
+  `pdf.worker.mjs`,
+  import.meta.url,
 ).toString();
 
 const PDFRenderer: DocRenderer = ({ mainState }) => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,9 @@
     "skipLibCheck": true,
     "noEmit": true,
     "resolveJsonModule": true,
-    "types": ["vitest/globals"]
+    "moduleResolution": "node",
+    "types": ["vitest/globals"],
+    "module": "esnext"
   },
   "exclude": ["node_modules", "use-cases"]
 }


### PR DESCRIPTION
The effort here is to try and eliminate the usage of unpkg.com for loading the workerSrc.  See https://github.com/cyntler/react-doc-viewer/issues/285 for details.