### PR TITLE
fix: fix styled components prop pollution in image renderer

### DIFF
--- a/src/renderers/image/index.tsx
+++ b/src/renderers/image/index.tsx
@@ -2,12 +2,11 @@ import React from "react";
 import styled from "styled-components";
 import { DocRenderer } from "../..";
 
-const ImageProxyRenderer: DocRenderer = (props) => {
-  const {
-    mainState: { currentDocument },
-    children,
-  } = props;
-
+const ImageProxyRenderer: DocRenderer = ({
+  mainState: { currentDocument },
+  children,
+  ...props
+}) => {
   if (!currentDocument) return null;
 
   return (


### PR DESCRIPTION
fixes the error reported by styled components ^6.0.0 when unrecognized props gets applied to the DOM

![image](https://github.com/user-attachments/assets/e05a9ce6-ce6a-407e-adab-a0be2e0d100b)
