### PR TITLE
fix: correct Chinese and special characters display in HTML renderer

### DIFF
--- a/src/renderers/html/index.tsx
+++ b/src/renderers/html/index.tsx
@@ -8,22 +8,18 @@ const HTMLRenderer: DocRenderer = ({ mainState: { currentDocument } }) => {
     const b64String = currentDocument?.fileData as string;
 
     let encoding = "";
-    const bodyBase64 =
-      b64String?.replace(
-        /^data:text\/html;(?:charset=([^;]*);)?base64,/,
-        (_, charset) => {
-          encoding = charset;
-          return "";
-        },
-      ) || "";
+    const bodyBase64 = b64String?.replace(
+      /^data:text\/html;(?:charset=([^;]*);)?base64,/,
+      (_, charset) => {
+        encoding = charset || "utf-8";
+        return "";
+      },
+    );
     let body: string = window.atob(bodyBase64);
 
-    if (encoding) {
-      // decode charset
-      const buffer = new Uint8Array(body.length);
-      for (let i = 0; i < body.length; i++) buffer[i] = body.charCodeAt(i);
-      body = new TextDecoder(encoding).decode(buffer);
-    }
+    // decode charset
+    const buffer = Uint8Array.from(body, (c) => c.charCodeAt(0));
+    body = new TextDecoder(encoding).decode(buffer);
 
     const iframeCont = document.getElementById(
       "html-body",


### PR DESCRIPTION
### Issue Description
The current HTML renderer has issues with displaying non-ASCII characters (like Chinese, Japanese, Korean) correctly. This is because:

1. The original code only applies character encoding handling when `encoding` is explicitly specified in the data URL
2. When there's no explicit charset in the data URL, it skips the decoding process entirely, leading to garbled characters

### Root Cause
The issue occurs because Base64-encoded HTML content needs proper character encoding handling regardless of whether the charset is explicitly specified. When `atob()` decodes Base64 content, it returns a string of bytes using Latin1 encoding, which needs to be properly decoded using the correct charset. For more information about Base64, see [MDN documentation](https://developer.mozilla.org/en-US/docs/Glossary/Base64).

### Changes Made
```typescript
// Before
if (encoding) {
  const buffer = new Uint8Array(body.length);
  for (let i = 0; i < body.length; i++) buffer[i] = body.charCodeAt(i);
  body = new TextDecoder(encoding).decode(buffer);
}
```

```typescript
// After
// Always handle encoding with utf-8 as fallback
encoding = charset || "utf-8";
const buffer = Uint8Array.from(body, (c) => c.charCodeAt(0));
body = new TextDecoder(encoding).decode(buffer);
```

### Key Improvements
1. Always perform character encoding conversion, not just when charset is specified
2. Use "utf-8" as fallback encoding when charset is not specified
3. Use `Uint8Array.from()` for more concise and efficient buffer creation
4. Ensure consistent handling of all non-ASCII characters

### Testing
Tested with HTML files containing:
- Chinese characters
- Mixed ASCII and non-ASCII content

All characters now display correctly regardless of whether charset is explicitly specified in the data URL.